### PR TITLE
Add idempotency guard to feature reviewer sub-issue creation

### DIFF
--- a/tools/feature-reviewer/core/orchestrator.ts
+++ b/tools/feature-reviewer/core/orchestrator.ts
@@ -62,6 +62,21 @@ export class FeatureReviewOrchestrator {
       console.log(`✅ Issue #${issue.number}: ${issue.title}`);
       console.log('');
 
+      const subIssueTitle = `[レビュー・テスト観点] ${issue.title}`;
+
+      console.log('🔁 Checking for existing sub-issue...');
+      const existingSubIssue = await this.issueClient.findIssueByTitleAndParent(
+        subIssueTitle,
+        issue.number
+      );
+      if (existingSubIssue) {
+        console.log('ℹ️ Existing sub-issue found. Skipping creation.');
+        console.log(
+          `   Issue #${existingSubIssue.number}: ${existingSubIssue.html_url}`
+        );
+        return;
+      }
+
       // ====== Phase 2: Issue分析 ======
       console.log('🔍 Analyzing issue with Claude AI...');
       console.log('   (This may take several minutes)');
@@ -74,7 +89,6 @@ export class FeatureReviewOrchestrator {
       console.log('');
 
       // ====== Phase 3: サブIssue作成 ======
-      const subIssueTitle = `[レビュー・テスト観点] ${issue.title}`;
       const subIssueMarkdown = await convertToSubIssueMarkdown(
         guidelines,
         issue.number,

--- a/tools/shared/github/issue-client.ts
+++ b/tools/shared/github/issue-client.ts
@@ -74,6 +74,43 @@ export class IssueClient {
   }
 
   /**
+   * 既存のサブIssueを検索
+   *
+   * @param title 探索するIssueタイトル
+   * @param parentIssueNumber 親Issue番号（本文内の参照を確認）
+   * @returns 見つかったIssue情報。存在しない場合はnull
+   */
+  async findIssueByTitleAndParent(
+    title: string,
+    parentIssueNumber: number
+  ): Promise<IssueInfo | null> {
+    const issues = await this.octokit.paginate(
+      this.octokit.rest.issues.listForRepo,
+      {
+        owner: this.owner,
+        repo: this.repo,
+        state: 'all',
+        per_page: 100
+      }
+    );
+
+    for (const issue of issues) {
+      if ('pull_request' in issue) continue; // PRは除外
+      if (issue.title !== title) continue;
+      if (!issue.body?.includes(`#${parentIssueNumber}`)) continue;
+
+      return {
+        number: issue.number,
+        title: issue.title,
+        body: issue.body || '',
+        html_url: issue.html_url
+      };
+    }
+
+    return null;
+  }
+
+  /**
    * Issueにコメントを投稿
    *
    * @param issueNumber Issue番号


### PR DESCRIPTION
## Summary
- add repository search to detect existing review sub-issues before creating new ones
- stop the feature reviewer workflow early when a matching sub-issue already exists, avoiding duplicates

## Testing
- bun run lint *(fails: Missing type definitions for bun-types in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692970e0d624832e917d107f8b81c289)