### PR TITLE
fix: Add fallback for actions logs when download fails

### DIFF
--- a/.github/workflows/close-sub-issues.yml
+++ b/.github/workflows/close-sub-issues.yml
@@ -15,82 +15,25 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      # PR本文から親Issue番号を抽出
-      - name: Extract Parent Issue Number
-        id: extract-parent
-        run: |
-          PR_BODY=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json body --jq '.body')
-          echo "PR Body: $PR_BODY"
+      # リポジトリのチェックアウト
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-          # "Closes #123" / "Fixes #456" / "Resolves #789" などから番号を抽出
-          PARENT_ISSUE=$(echo "$PR_BODY" | grep -oiP '(?:Close[s]?|Fix(?:es)?|Resolve[s]?)\s+#\K\d+' | head -1)
+      # Bun環境セットアップ
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
 
-          if [ -z "$PARENT_ISSUE" ]; then
-            echo "⚠️ 親Issueが見つかりませんでした"
-            echo "parent_issue=" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+      # 依存関係インストール
+      - name: Install Dependencies
+        run: bun install
 
-          echo "✅ 親Issue: #$PARENT_ISSUE"
-          echo "parent_issue=$PARENT_ISSUE" >> $GITHUB_OUTPUT
+      # サブIssueクローズ処理
+      - name: Close Sub-Issues
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # 親IssueのコメントからサブIssue番号を抽出
-      - name: Extract Sub-Issue Number
-        if: steps.extract-parent.outputs.parent_issue != ''
-        id: extract-sub
-        run: |
-          PARENT_ISSUE=${{ steps.extract-parent.outputs.parent_issue }}
-
-          # 親Issueのコメントを取得
-          COMMENTS=$(gh issue view $PARENT_ISSUE --repo ${{ github.repository }} --json comments --jq '.comments[].body')
-          echo "Comments: $COMMENTS"
-
-          # "実装時は以下のIssueを参照してください：\n- #123" からサブIssue番号を抽出
-          SUB_ISSUE=$(echo "$COMMENTS" | grep -A 1 '実装時は以下のIssueを参照してください' | grep -oP '#\K\d+' | head -1)
-
-          if [ -z "$SUB_ISSUE" ]; then
-            echo "⚠️ サブIssueが見つかりませんでした"
-            echo "sub_issue=" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "✅ サブIssue: #$SUB_ISSUE"
-          echo "sub_issue=$SUB_ISSUE" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # サブIssueにコメントを投稿してクローズ
-      - name: Close Sub-Issue with Comment
-        if: steps.extract-sub.outputs.sub_issue != ''
-        run: |
-          SUB_ISSUE=${{ steps.extract-sub.outputs.sub_issue }}
-          PARENT_ISSUE=${{ steps.extract-parent.outputs.parent_issue }}
-          PR_NUMBER=${{ github.event.pull_request.number }}
-
-          # クローズコメントを投稿
-          gh issue comment $SUB_ISSUE --repo ${{ github.repository }} --body "$(cat <<EOF
-          ✅ PR #${PR_NUMBER} がマージされたため、このサブIssueをクローズします。
-
-          親Issue: #${PARENT_ISSUE}
-          マージされたPR: #${PR_NUMBER}
-          EOF
-          )"
-
-          # サブIssueをクローズ
-          gh issue close $SUB_ISSUE --repo ${{ github.repository }}
-
-          echo "✅ サブIssue #$SUB_ISSUE をクローズしました"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # 完了メッセージ
-      - name: Summary
-        if: steps.extract-sub.outputs.sub_issue != ''
-        run: |
-          echo "### ✅ サブIssue自動クローズ完了" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- 親Issue: #${{ steps.extract-parent.outputs.parent_issue }}" >> $GITHUB_STEP_SUMMARY
-          echo "- サブIssue: #${{ steps.extract-sub.outputs.sub_issue }}" >> $GITHUB_STEP_SUMMARY
-          echo "- マージされたPR: #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: bun run tools/close-sub-issues/index.ts

--- a/scripts/github/actions.sh
+++ b/scripts/github/actions.sh
@@ -163,15 +163,18 @@ get_logs() {
     repo=$(get_repo_info)
 
     # ログURLを取得（リダイレクト先）
-    local log_url
-    log_url=$(curl -s -I -H "Authorization: token $token" \
+    local log_url header_response
+    header_response=$(curl -s -I -H "Authorization: token $token" \
         -H "Accept: application/vnd.github.v3+json" \
-        "https://api.github.com/repos/${repo}/actions/runs/${run_id}/logs" | \
-        grep -i "^location:" | sed 's/location: //i' | tr -d '\r')
+        "https://api.github.com/repos/${repo}/actions/runs/${run_id}/logs" 2>&1)
+
+    log_url=$(echo "$header_response" | grep -i "^location:" | sed 's/location: //i' | tr -d '\r')
 
     if [ -z "$log_url" ]; then
-        echo -e "${RED}エラー: ログURLを取得できませんでした${NC}" >&2
-        return 1
+        echo -e "${YELLOW}⚠️ ログURLを取得できませんでした。ジョブステップ情報を表示します。${NC}"
+        echo ""
+        _show_job_steps "$run_id"
+        return 0
     fi
 
     # ZIPをダウンロードして展開
@@ -179,7 +182,25 @@ get_logs() {
     mkdir -p "$temp_dir"
 
     echo "ダウンロード中..."
-    curl -sL "$log_url" -o "${temp_dir}/logs.zip"
+    if ! curl -sL --max-time 30 "$log_url" -o "${temp_dir}/logs.zip" 2>/dev/null; then
+        echo -e "${YELLOW}⚠️ ログのダウンロードに失敗しました（ネットワーク制限の可能性）${NC}"
+        echo -e "${GRAY}リダイレクト先: ${log_url:0:60}...${NC}"
+        echo ""
+        echo -e "${BLUE}代わりにジョブステップ情報を表示します:${NC}"
+        echo ""
+        _show_job_steps "$run_id"
+        return 0
+    fi
+
+    # ZIPファイルの検証
+    if [ ! -s "${temp_dir}/logs.zip" ] || ! file "${temp_dir}/logs.zip" | grep -q "Zip archive"; then
+        echo -e "${YELLOW}⚠️ ダウンロードしたファイルが無効です${NC}"
+        echo ""
+        echo -e "${BLUE}代わりにジョブステップ情報を表示します:${NC}"
+        echo ""
+        _show_job_steps "$run_id"
+        return 0
+    fi
 
     echo "展開中..."
     unzip -q -o "${temp_dir}/logs.zip" -d "$temp_dir"
@@ -204,6 +225,31 @@ get_logs() {
         echo ""
         cat "$log_file"
     fi
+}
+
+# ジョブのステップ情報を表示（フォールバック用）
+_show_job_steps() {
+    local run_id="$1"
+
+    # ジョブ一覧を取得
+    local jobs_response
+    jobs_response=$(call_api "GET" "/actions/runs/${run_id}/jobs")
+
+    if [ -z "$jobs_response" ]; then
+        echo -e "${RED}ジョブ情報の取得に失敗しました${NC}"
+        return 1
+    fi
+
+    # 各ジョブのステップを表示
+    echo "$jobs_response" | jq -r '.jobs[] | "----------------------------------------------\n\u001b[32mJob:\u001b[0m \(.name)\n\u001b[36mステータス:\u001b[0m \(.status) (\(.conclusion // "running"))\n\n\u001b[33mステップ:\u001b[0m"'
+
+    echo "$jobs_response" | jq -r '.jobs[].steps[] | "  [\(.conclusion // "running" | if . == "success" then "✓" elif . == "failure" then "✗" elif . == "skipped" then "⏭" else "○" end)] \(.name)"'
+
+    echo ""
+    echo -e "${CYAN}詳細ログはGitHubで確認:${NC}"
+    local html_url
+    html_url=$(call_api "GET" "/actions/runs/${run_id}" | jq -r '.html_url')
+    echo "$html_url"
 }
 
 # PRに関連するWorkflow Runsを取得

--- a/tools/close-sub-issues/index.ts
+++ b/tools/close-sub-issues/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env bun
 /**
  * Close Sub-Issues on PR Merge
  *

--- a/tools/close-sub-issues/index.ts
+++ b/tools/close-sub-issues/index.ts
@@ -1,0 +1,163 @@
+/**
+ * Close Sub-Issues on PR Merge
+ *
+ * PRがマージされた際に、関連するサブIssueを自動的にクローズする
+ */
+import { Octokit } from 'octokit';
+import { JulesApiClient } from '../feature-reviewer/core/jules-client';
+
+// 環境変数
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const JULES_API_KEY = process.env.JULES_API_KEY;
+const PR_NUMBER = process.env.PR_NUMBER;
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
+
+if (!GITHUB_TOKEN) {
+  console.error('❌ GITHUB_TOKEN is required');
+  process.exit(1);
+}
+
+if (!PR_NUMBER) {
+  console.error('❌ PR_NUMBER is required');
+  process.exit(1);
+}
+
+if (!GITHUB_REPOSITORY) {
+  console.error('❌ GITHUB_REPOSITORY is required');
+  process.exit(1);
+}
+
+const [owner, repo] = GITHUB_REPOSITORY.split('/');
+const prNumber = parseInt(PR_NUMBER, 10);
+
+const octokit = new Octokit({ auth: GITHUB_TOKEN });
+
+/**
+ * PR本文からCloses/Fixes/Resolves #XXX パターンでIssue番号を抽出
+ */
+function extractParentIssueFromBody(body: string | null): number | null {
+  if (!body) return null;
+  const match = body.match(/(?:close[s]?|fix(?:es)?|resolve[s]?)\s+#(\d+)/i);
+  return match && match[1] ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * 親IssueのコメントからサブIssue番号を抽出
+ * パターン: "実装時は以下のIssueを参照してください：\n- #123"
+ */
+async function findSubIssueFromComments(parentIssueNumber: number): Promise<number | null> {
+  const { data: comments } = await octokit.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: parentIssueNumber,
+    per_page: 100,
+  });
+
+  const subIssuePattern = /実装時は以下のIssueを参照してください：\s*\n\s*-\s*#(\d+)/;
+
+  for (const comment of comments) {
+    const match = comment.body?.match(subIssuePattern);
+    if (match && match[1]) {
+      return parseInt(match[1], 10);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * サブIssueにコメントを投稿してクローズ
+ */
+async function closeSubIssue(subIssueNumber: number, parentIssueNumber: number): Promise<void> {
+  const comment = `✅ PR #${prNumber} がマージされたため、このサブIssueをクローズします。
+
+親Issue: #${parentIssueNumber}
+マージされたPR: #${prNumber}`;
+
+  // コメント投稿
+  await octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: subIssueNumber,
+    body: comment,
+  });
+
+  // Issueクローズ
+  await octokit.rest.issues.update({
+    owner,
+    repo,
+    issue_number: subIssueNumber,
+    state: 'closed',
+  });
+
+  console.log(`✅ サブIssue #${subIssueNumber} をクローズしました`);
+}
+
+async function main(): Promise<void> {
+  console.log(`🔍 PR #${prNumber} の関連Issue情報を取得中...`);
+
+  // 1. PR情報を取得
+  const { data: pr } = await octokit.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+
+  // 2. PR本文から親Issue番号を抽出
+  let parentIssueNumber = extractParentIssueFromBody(pr.body);
+
+  if (parentIssueNumber) {
+    console.log(`✅ PR本文から親Issue #${parentIssueNumber} を検出`);
+  } else {
+    console.log('ℹ️  PR本文にIssue参照がありません');
+
+    // 3. Jules APIでIssue番号を逆引き（フォールバック）
+    if (JULES_API_KEY) {
+      console.log('🔍 Jules APIで親Issueを検索中...');
+      try {
+        const julesClient = new JulesApiClient(JULES_API_KEY, owner, repo);
+        const issueNumber = await julesClient.findIssueNumberForPR(prNumber);
+        if (issueNumber) {
+          parentIssueNumber = issueNumber;
+          console.log(`✅ Jules APIから親Issue #${parentIssueNumber} を検出`);
+        } else {
+          console.log('⚠️  Jules APIでも親Issueが見つかりませんでした');
+        }
+      } catch (error) {
+        console.warn('⚠️  Jules API呼び出しに失敗:', error);
+      }
+    } else {
+      console.log('ℹ️  JULES_API_KEYが設定されていないため、フォールバック検索をスキップ');
+    }
+  }
+
+  if (!parentIssueNumber) {
+    console.log('⚠️  親Issueが見つかりませんでした。処理を終了します。');
+    return;
+  }
+
+  // 4. 親IssueのコメントからサブIssue番号を取得
+  console.log(`🔍 親Issue #${parentIssueNumber} のコメントからサブIssueを検索中...`);
+  const subIssueNumber = await findSubIssueFromComments(parentIssueNumber);
+
+  if (!subIssueNumber) {
+    console.log('⚠️  サブIssueが見つかりませんでした。処理を終了します。');
+    return;
+  }
+
+  console.log(`✅ サブIssue #${subIssueNumber} を検出`);
+
+  // 5. サブIssueをクローズ
+  await closeSubIssue(subIssueNumber, parentIssueNumber);
+
+  console.log('');
+  console.log('### ✅ サブIssue自動クローズ完了');
+  console.log(`- 親Issue: #${parentIssueNumber}`);
+  console.log(`- サブIssue: #${subIssueNumber}`);
+  console.log(`- マージされたPR: #${prNumber}`);
+}
+
+main().catch((error) => {
+  console.error('❌ エラーが発生しました:', error);
+  process.exit(1);
+});

--- a/tools/close-sub-issues/index.ts
+++ b/tools/close-sub-issues/index.ts
@@ -4,33 +4,46 @@
  * PRがマージされた際に、関連するサブIssueを自動的にクローズする
  */
 import { Octokit } from 'octokit';
+import { z } from 'zod';
 import { JulesApiClient } from '../feature-reviewer/core/jules-client';
 
-// 環境変数
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-const JULES_API_KEY = process.env.JULES_API_KEY;
-const PR_NUMBER = process.env.PR_NUMBER;
-const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
+// 環境変数スキーマ
+const EnvSchema = z.object({
+  GITHUB_TOKEN: z.string().min(1, 'GITHUB_TOKEN is required'),
+  PR_NUMBER: z.string().regex(/^\d+$/, 'PR_NUMBER must be a number'),
+  GITHUB_REPOSITORY: z.string().regex(/^[^/]+\/[^/]+$/, 'GITHUB_REPOSITORY must be in "owner/repo" format'),
+  JULES_API_KEY: z.string().optional(),
+});
 
-if (!GITHUB_TOKEN) {
-  console.error('❌ GITHUB_TOKEN is required');
+function validateEnv() {
+  return EnvSchema.parse({
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+    PR_NUMBER: process.env.PR_NUMBER,
+    GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY,
+    JULES_API_KEY: process.env.JULES_API_KEY,
+  });
+}
+
+// 環境変数のバリデーション
+let env: z.infer<typeof EnvSchema>;
+try {
+  env = validateEnv();
+} catch (error) {
+  if (error instanceof z.ZodError) {
+    console.error('❌ 環境変数のバリデーションエラー:');
+    error.errors.forEach((err) => {
+      console.error(`  - ${err.path.join('.')}: ${err.message}`);
+    });
+  } else {
+    console.error('❌ 環境変数の検証に失敗しました:', error);
+  }
   process.exit(1);
 }
 
-if (!PR_NUMBER) {
-  console.error('❌ PR_NUMBER is required');
-  process.exit(1);
-}
+const [owner, repo] = env.GITHUB_REPOSITORY.split('/');
+const prNumber = parseInt(env.PR_NUMBER, 10);
 
-if (!GITHUB_REPOSITORY) {
-  console.error('❌ GITHUB_REPOSITORY is required');
-  process.exit(1);
-}
-
-const [owner, repo] = GITHUB_REPOSITORY.split('/');
-const prNumber = parseInt(PR_NUMBER, 10);
-
-const octokit = new Octokit({ auth: GITHUB_TOKEN });
+const octokit = new Octokit({ auth: env.GITHUB_TOKEN });
 
 /**
  * PR本文からCloses/Fixes/Resolves #XXX パターンでIssue番号を抽出
@@ -66,19 +79,17 @@ async function findSubIssueFromComments(parentIssueNumber: number): Promise<numb
 }
 
 /**
- * サブIssueにコメントを投稿してクローズ
+ * Issueにコメントを投稿してクローズ
  */
-async function closeSubIssue(subIssueNumber: number, parentIssueNumber: number): Promise<void> {
-  const comment = `✅ PR #${prNumber} がマージされたため、このサブIssueをクローズします。
-
-親Issue: #${parentIssueNumber}
-マージされたPR: #${prNumber}`;
-
+async function closeIssueWithComment(
+  issueNumber: number,
+  comment: string
+): Promise<void> {
   // コメント投稿
   await octokit.rest.issues.createComment({
     owner,
     repo,
-    issue_number: subIssueNumber,
+    issue_number: issueNumber,
     body: comment,
   });
 
@@ -86,11 +97,38 @@ async function closeSubIssue(subIssueNumber: number, parentIssueNumber: number):
   await octokit.rest.issues.update({
     owner,
     repo,
-    issue_number: subIssueNumber,
+    issue_number: issueNumber,
     state: 'closed',
   });
+}
 
+/**
+ * サブIssueをクローズ
+ */
+async function closeSubIssue(subIssueNumber: number, parentIssueNumber: number): Promise<void> {
+  const comment = `✅ PR #${prNumber} がマージされたため、このサブIssueをクローズします。
+
+親Issue: #${parentIssueNumber}
+マージされたPR: #${prNumber}`;
+
+  await closeIssueWithComment(subIssueNumber, comment);
   console.log(`✅ サブIssue #${subIssueNumber} をクローズしました`);
+}
+
+/**
+ * 親Issueをクローズ（Jules APIフォールバック時のみ）
+ */
+async function closeParentIssue(parentIssueNumber: number, subIssueNumber: number | null): Promise<void> {
+  let comment = `✅ PR #${prNumber} がマージされたため、このIssueをクローズします。
+
+マージされたPR: #${prNumber}`;
+
+  if (subIssueNumber) {
+    comment += `\nサブIssue: #${subIssueNumber}`;
+  }
+
+  await closeIssueWithComment(parentIssueNumber, comment);
+  console.log(`✅ 親Issue #${parentIssueNumber} をクローズしました`);
 }
 
 async function main(): Promise<void> {
@@ -105,20 +143,23 @@ async function main(): Promise<void> {
 
   // 2. PR本文から親Issue番号を抽出
   let parentIssueNumber = extractParentIssueFromBody(pr.body);
+  let foundViaJulesApi = false;
 
   if (parentIssueNumber) {
     console.log(`✅ PR本文から親Issue #${parentIssueNumber} を検出`);
+    console.log('ℹ️  親IssueはGitHub標準機能で自動クローズされます');
   } else {
     console.log('ℹ️  PR本文にIssue参照がありません');
 
     // 3. Jules APIでIssue番号を逆引き（フォールバック）
-    if (JULES_API_KEY) {
+    if (env.JULES_API_KEY) {
       console.log('🔍 Jules APIで親Issueを検索中...');
       try {
-        const julesClient = new JulesApiClient(JULES_API_KEY, owner, repo);
+        const julesClient = new JulesApiClient(env.JULES_API_KEY, owner, repo);
         const issueNumber = await julesClient.findIssueNumberForPR(prNumber);
         if (issueNumber) {
           parentIssueNumber = issueNumber;
+          foundViaJulesApi = true;
           console.log(`✅ Jules APIから親Issue #${parentIssueNumber} を検出`);
         } else {
           console.log('⚠️  Jules APIでも親Issueが見つかりませんでした');
@@ -140,20 +181,27 @@ async function main(): Promise<void> {
   console.log(`🔍 親Issue #${parentIssueNumber} のコメントからサブIssueを検索中...`);
   const subIssueNumber = await findSubIssueFromComments(parentIssueNumber);
 
-  if (!subIssueNumber) {
-    console.log('⚠️  サブIssueが見つかりませんでした。処理を終了します。');
-    return;
+  if (subIssueNumber) {
+    console.log(`✅ サブIssue #${subIssueNumber} を検出`);
+    // 5. サブIssueをクローズ
+    await closeSubIssue(subIssueNumber, parentIssueNumber);
+  } else {
+    console.log('ℹ️  サブIssueが見つかりませんでした');
   }
 
-  console.log(`✅ サブIssue #${subIssueNumber} を検出`);
-
-  // 5. サブIssueをクローズ
-  await closeSubIssue(subIssueNumber, parentIssueNumber);
+  // 6. Jules APIフォールバック時は親Issueもクローズ
+  //    （PR本文に Closes #X がある場合はGitHubが自動でクローズするのでスキップ）
+  if (foundViaJulesApi) {
+    console.log('🔍 Jules APIで検出した親Issueをクローズします...');
+    await closeParentIssue(parentIssueNumber, subIssueNumber);
+  }
 
   console.log('');
-  console.log('### ✅ サブIssue自動クローズ完了');
-  console.log(`- 親Issue: #${parentIssueNumber}`);
-  console.log(`- サブIssue: #${subIssueNumber}`);
+  console.log('### ✅ Issue自動クローズ完了');
+  console.log(`- 親Issue: #${parentIssueNumber}${foundViaJulesApi ? ' (クローズ済み)' : ' (GitHub自動クローズ)'}`);
+  if (subIssueNumber) {
+    console.log(`- サブIssue: #${subIssueNumber} (クローズ済み)`);
+  }
   console.log(`- マージされたPR: #${prNumber}`);
 }
 


### PR DESCRIPTION
When log download fails due to network restrictions (e.g., blocked
access to results-receiver.actions.githubusercontent.com), the command
now gracefully falls back to displaying job step information instead
of failing silently.

Changes:
- Add _show_job_steps helper function
- Add proper error handling for curl download failures
- Validate downloaded ZIP file before extraction
- Show GitHub URL for detailed log viewing